### PR TITLE
Creación / Vinculación de perfíl de Familiar

### DIFF
--- a/app/Http/Controllers/Api/Personas/v1/PersonasCrud.php
+++ b/app/Http/Controllers/Api/Personas/v1/PersonasCrud.php
@@ -106,7 +106,7 @@ class PersonasCrud extends Controller
             $persona = Personas::create($req->except("vinculo"));
         }
 
-        if($persona != null && $persona->familiar && !$persona->alumno) {
+        if($persona != null && $persona->familiar) {
             $this->updatePersonaIdFromUserSocial($persona->id);
         }
 


### PR DESCRIPTION
Permite agregar/vincular perfil de  familiares que también sean alumnos. Anteriormente no se podía vincular a un usuario social un perfil de familiar que también sea alumno.