### PR TITLE
Habilitar en algunas instituciones realizar Reubicaciones a diferentes años

### DIFF
--- a/app/Http/Controllers/Api/Inscripcion/InscripcionReubicacion.php
+++ b/app/Http/Controllers/Api/Inscripcion/InscripcionReubicacion.php
@@ -36,8 +36,8 @@ class InscripcionReubicacion extends Controller
         $cicloActual = Ciclos::where('nombre',Carbon::now()->year)->first();
 
         // Solo se permite reubicar cursos del mismo año
-        if($cursoFrom->anio == $cursoTo->anio)
-        {
+        //if($cursoFrom->anio == $cursoTo->anio)
+        //{
             foreach($cursoInscripcion as $curins)
             {
                 // Se edita el curso anterior por el nuevo
@@ -55,6 +55,7 @@ class InscripcionReubicacion extends Controller
             ];
 
             Log::info("Reubicacion ({$user->id}) {$user->username} | {$cursoFrom->id} => {$cursoTo->id}",$output);
+        /*
         } else {
             $output = [
                 'error'=>"Los años son diferentes, no se puede realizar la reubicacion"
@@ -62,7 +63,7 @@ class InscripcionReubicacion extends Controller
 
             Log::warning("Reubicacion ({$user->id}) {$user->username} | {$cursoFrom->id} => {$cursoTo->id}",$output);
         }
-
+        */
         return $output;
     }
 


### PR DESCRIPTION
Modificación provisoria para que las escuelas Especiales y Experimentales requieren -a veces- REUBICAR un alumno a una sección de un año superior.  

Queda pendiente la correcta modificación de la lógica según el CUE de la Institución que requiere esta excepción.