### PR TITLE
Fix vinculación de alumnos

### DIFF
--- a/app/Http/Controllers/Api/Matriculas/v1/MatriculasPorSeccion.php
+++ b/app/Http/Controllers/Api/Matriculas/v1/MatriculasPorSeccion.php
@@ -115,7 +115,7 @@ class MatriculasPorSeccion extends Controller
             // Se carga la relacion con el modelo Titulacion
             $item->titulacion = Titulacion::select('nombre','nombre_abreviado')->find($item->titulacion_id);
 
-            // Modifica las plazas y vacantes del ciclo 2019
+            /*// Modifica las plazas y vacantes del ciclo 2019
             if(Input::get('ciclo')==2019)
             {
                 switch ($item->nivel_servicio)
@@ -130,7 +130,7 @@ class MatriculasPorSeccion extends Controller
                         $item->vacantes= $item->plazas - $item->matriculas;
                         break;
                 }
-            }
+            }*/
         }
 
 

--- a/app/Http/Controllers/Api/Saneo/SaneoRepitencia.php
+++ b/app/Http/Controllers/Api/Saneo/SaneoRepitencia.php
@@ -60,7 +60,7 @@ class SaneoRepitencia extends Controller
         Log::info("SaneoRepitencia:doSaneo()");
         $this->doSaneo($response);
         $response['data'] = RepitenciaResource::collection(collect($response['data']));
-        Log::info("SaneoRepitencia:Finalizado ".$page." de ".$response['last_page']);
+        Log::info("SaneoRepitencia:Finalizado page: ".$page." last_page: ".$response['last_page']);
         return $response;
     }
 

--- a/app/Jobs/WhileJobSaneoRepitenciaAndPromocion.php
+++ b/app/Jobs/WhileJobSaneoRepitenciaAndPromocion.php
@@ -1,7 +1,6 @@
 <?php
 
 namespace App\Jobs;
-ini_set('max_execution_time', '3');
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Queue\SerializesModels;
@@ -27,7 +26,7 @@ class WhileJobSaneoRepitenciaAndPromocion implements ShouldQueue
      */
     public function __construct($ciclo=2019,$page=1,$por_pagina=10,$ultima_pagina=null)
     {
-        $this->build = 2;
+        $this->build = 3;
 
         $this->ciclo= $ciclo;
         $this->page = $page;
@@ -43,13 +42,12 @@ class WhileJobSaneoRepitenciaAndPromocion implements ShouldQueue
     public function handle()
     {
         $nextPage = $this->page + 1;
-        Log::info("ARTISAN WhileJobSaneoRepitenciaAndPromocion: Build {$this->build}");
-        Log::info("ARTISAN WhileJobSaneoRepitenciaAndPromocion: Prepare Jobs $nextPage/{$this->ultima_pagina}");
-        while($nextPage < $this->ultima_pagina) {
-            Log::info("ARTISAN JobSaneoRepitenciaAndPromocion::dispatch: $nextPage");
-            JobSaneoRepitenciaAndPromocion::dispatch($this->ciclo,$nextPage,$this->por_pagina)->delay(now()->addMinutes(10));
+        Log::info("ARTISAN WhileJobSaneoRepitenciaAndPromocion: Build {$this->build} | Prepare Jobs $nextPage / {$this->ultima_pagina}");
+        while($nextPage <= $this->ultima_pagina) {
+            Log::info("ARTISAN JobSaneoRepitenciaAndPromocion::dispatch: $nextPage / {$this->ultima_pagina}");
+            JobSaneoRepitenciaAndPromocion::dispatch($this->ciclo,$nextPage,$this->por_pagina); //->delay(now()->addMinutes(10));
             $nextPage++;
         }
-        Log::info("ARTISAN WhileJobSaneoRepitenciaAndPromocion: Jobs Created (Total: $nextPage / {$this->ultima_pagina})");
+        Log::info("ARTISAN WhileJobSaneoRepitenciaAndPromocion: Jobs Created {$this->ultima_pagina}");
     }
 }


### PR DESCRIPTION
- Recuperación de último alumno en lugar del primero.
Esto generaba un error a la hora de verificar la relación en las instituciones ya que el alumno que se vinculaba podía o no formar parte de la institución actual.