### PR TITLE
Se quita filtro 'con division 'por defecto en matriculas

### DIFF
--- a/app/Http/Controllers/Api/Matriculas/v1/MatriculasPorSeccion.php
+++ b/app/Http/Controllers/Api/Matriculas/v1/MatriculasPorSeccion.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\Log;
 
 class MatriculasPorSeccion extends Controller
 {
@@ -241,10 +242,6 @@ class MatriculasPorSeccion extends Controller
         if(isset($anio)) {
             $query = $query->where('cursos.anio',$anio);
         }
-
-        // Seteo la division para que por defecto traiga los cursos que contengan division
-        if($division == '')
-        { $division = 'con'; }
         
         if(isset($division)) {
             if($division=='vacia' || $division=='sin' || $division == null) {


### PR DESCRIPTION
Se deberá setear la variable 'division' en el front